### PR TITLE
Fix for keyboard and a few cleanups

### DIFF
--- a/arch/idt.c
+++ b/arch/idt.c
@@ -127,32 +127,6 @@ void __idt_default_handler() {
 	console_write("hello!");
 }
 
-
-char num_tochar(int i) {
-	if ( i == 0 )
-	  return '0';
-	if ( i == 1 )
-	  return '1';	
-	if ( i == 2 )
-	  return '2';
-	if ( i == 3 )
-	  return '3';	
-	if ( i == 4 )
-	  return '4';	
-	if ( i == 5 )
-	  return '5';	
-	if ( i == 6 )
-	  return '6';
-	if ( i == 7 )
-	  return '7';	
-	if ( i == 8 )
-	  return '8';
-	if ( i == 9 )
-	  return '9';
-	return -1;	
-//	for( int i = sizeof(i) / 8; i > 0; i-- ) {
-}
-
 void irq_handler(regs_t r) {
 	/*console_write("\n");
 	console_write("ds:");

--- a/arch/idt.c
+++ b/arch/idt.c
@@ -1,5 +1,6 @@
 #include <depthos/idt.h>
 
+void idt_regh(uint8_t i,uint32_t cb);
 int __init_idt = 0;
 
 #define idt_size 256

--- a/arch/intr.s
+++ b/arch/intr.s
@@ -26,9 +26,10 @@
 .macro IRQ_NOERRCODE num
 	.global intr\num
 	intr\num:
-		cli
-		pushl $\num
-		jmp irq_cstub
+		// push 0 in place of the error code
+		pushl	$0
+		pushl	$\num
+		jmp	irq_cstub
 .endm
 
 
@@ -194,28 +195,25 @@ intr_cstub:
 
 irq_cstub:
 	pusha
-	mov %ds,%ax
-	pushl %eax
-	mov $0x10, %ax
-	mov %ax, %ds
-	mov %ax, %es
-	mov %ax, %fs
-	mov %ax, %gs
-//	mov %esp, %eax
-//	pusha
+	push	%ds
+	push	%es
+	push	%gs
+	push	%fs
+	mov	$0x10, %ax
+	mov	%ax, %ds
+	mov	%ax, %es
+	mov	%ax, %fs
+	mov	%ax, %gs
 	// Call the kernel IRQ handler
-	call irq_handler
+	call	irq_handler
 
-	popl %eax
-	mov %ax,%ds
-	mov %ax,%es
-	mov %ax,%fs
-	mov %ax,%gs
-	
+	pop	%fs
+	pop	%gs
+	pop	%es
+	pop	%ds
 	popa
-//	popa
-	add $8, %esp
-	sti
+	// pop error code and IRQ number
+	add	$8, %esp
 	iret
 
 .extern idt_ptr

--- a/include/depthos/console.h
+++ b/include/depthos/console.h
@@ -39,12 +39,12 @@ void console_putchara(unsigned char c,uint8_t a);
 void console_putchar(unsigned char c);
 
 
-void console_write(unsigned char* buf);
-void console_writea(unsigned char* buf,uint8_t a);
+void console_write(const char* buf);
+void console_writea(const char* buf,uint8_t a);
 void console_write_dec(uint32_t v);
 void console_read();
 
-void console_write_color(unsigned char* buf,int8_t b,int8_t f);
+void console_write_color(const char* buf,int8_t b,int8_t f);
 void console_putchar_color(unsigned char c,int8_t b,int8_t f);
 
 void print_mod(char* buf,int m);

--- a/include/depthos/console.h
+++ b/include/depthos/console.h
@@ -42,6 +42,7 @@ void console_putchar(unsigned char c);
 void console_write(const char* buf);
 void console_writea(const char* buf,uint8_t a);
 void console_write_dec(uint32_t v);
+void console_write_int(uint32_t v, unsigned base);
 void console_read();
 
 void console_write_color(const char* buf,int8_t b,int8_t f);

--- a/include/depthos/idt.h
+++ b/include/depthos/idt.h
@@ -6,9 +6,9 @@
 #include <depthos/console.h>
 
 typedef struct __regs {
-    uint32_t ds;
+    uint32_t fs, gs, es, ds;
     uint32_t edi, esi, ebp, esp, ebx, edx, ecx, eax;
-	uint32_t int_num, err_code;
+    uint32_t int_num, err_code;
     uint32_t eip,cs,eflags,useresp,ss;
 } regs_t;
 

--- a/io/console.c
+++ b/io/console.c
@@ -127,7 +127,7 @@ void console_putchar(unsigned char c) {
 	console_putchara(c, ( dbcolor << 4 ) | ( dfcolor & 0x0F));
 }
 
-void console_write(unsigned char* buf) {
+void console_write(const char* buf) {
 	int i=0;
 	while(buf[i]) {
 		console_putchar(buf[i]);
@@ -135,7 +135,7 @@ void console_write(unsigned char* buf) {
 	}
 }
 
-void console_writea(unsigned char* buf,uint8_t a) {
+void console_writea(const char* buf,uint8_t a) {
 	int i = 0;
 	while(buf[i]) {
 		console_putchara(buf[i],a);
@@ -200,7 +200,7 @@ void console_write_dec(uint32_t v) {
 
 }
 
-void console_write_color(unsigned char* buf,int8_t b,int8_t f) {
+void console_write_color(const char* buf,int8_t b,int8_t f) {
 	if ( b < 0 ) {
 		b = dbcolor;
 	}

--- a/io/console.c
+++ b/io/console.c
@@ -143,33 +143,6 @@ void console_writea(const char* buf,uint8_t a) {
 	}
 }
 
-char* dec_tostr(uint32_t v) {
-	char c[32];
-	if(v==0)
-	{
-		c[0] = '0';
-		return c;
-	}
-
-	int acc = v;
-
-	int i = 0;
-	while(acc > 0)
-	{
-		c[i] = '0' + acc%10;
-		acc /= 10;
-		++i;
-	}
-	c[i] = 0;
-
-	char c2[32];
-	c2[i--] = 0;
-	int j = 0;
-	while(i >= 0)
-		c2[i--] = c[j++];
-	return c2;
-}
-
 void console_write_int(uint32_t v, unsigned base)
 {
 	int acc = v;

--- a/io/console.c
+++ b/io/console.c
@@ -170,34 +170,34 @@ char* dec_tostr(uint32_t v) {
 	return c2;
 }
 
-void console_write_dec(uint32_t v) {
-//	console_write(dec_tostr(v));
-// /*
-	if(v==0)
+void console_write_int(uint32_t v, unsigned base)
+{
+	int acc = v;
+	char c[33], c2[33];
+	int i = 0, j = 0;
+
+	if (v == 0 || base > 16)
 	{
 		console_putchar('0');
 		return;
 	}
 
-	int acc = v;
-	char c[32];
-	int i = 0;
-	while(acc > 0)
+	while (acc > 0)
 	{
-		c[i] = '0' + acc%10;
-		acc /= 10;
+		c[i] = "0123456789abcdef"[acc % base];
+		acc /= base;
 		++i;
 	}
 	c[i] = 0;
-
-	char c2[32];
 	c2[i--] = 0;
-	int j = 0;
 	while(i >= 0)
 		c2[i--] = c[j++];
-//	*/
-	console_write(c2);
 
+	console_write(c2);
+}
+
+void console_write_dec(uint32_t v) {
+	console_write_int(v, 10);
 }
 
 void console_write_color(const char* buf,int8_t b,int8_t f) {

--- a/kmain.c
+++ b/kmain.c
@@ -6,7 +6,7 @@
 extern unsigned short *videoMemory;
 void print_str(char* str) {
 
-  for (int i = 0; i < str[i] != '\0'; i++) {
+  for (int i = 0; str[i] != '\0'; i++) {
     videoMemory[i] = (videoMemory[i] & 0xFF00) | str[i];
   }
 

--- a/kmain.c
+++ b/kmain.c
@@ -121,5 +121,7 @@ void kmain(int magic,void *boot_ptr) {
 
 	__asm ( "movl $0x1,%%eax" : );
 	__asm ( "int $0x80" );
+	for (;;)
+		__asm __volatile ("hlt");
 	return;
 }

--- a/makefile
+++ b/makefile
@@ -58,12 +58,12 @@ build: kernel img iso
 kernel: $(CSOURCES) $(ASMSOURCES) $(NASMSOURCES) $(LDFILE)
 	@echo ---------- build kernel -----------
 ifeq ($(DEBUG),on)
-	$(CC) $(CEMU) -std=c$(CSTD) -g -c -DOSVER=\"$(OSVER)\" $(CSOURCES) $(CCFLAGS)
+	$(CC) $(CEMU) -std=c$(CSTD) -W -Wall -g -c -DOSVER=\"$(OSVER)\" $(CSOURCES) $(CCFLAGS)
 ifeq ($(DEBUG),true)
-	$(CC) $(CEMU) -std=c$(CSTD) -g -c -DOSVER=\"$(OSVER)\" $(CSOURCES) $(CCFLAGS)
+	$(CC) $(CEMU) -std=c$(CSTD) -W -Wall -g -c -DOSVER=\"$(OSVER)\" $(CSOURCES) $(CCFLAGS)
 endif
 else
-	$(CC) $(CEMU) -std=c$(CSTD) -c -DOSVER=\"$(OSVER)\" $(CSOURCES) $(CCFLAGS)
+	$(CC) $(CEMU) -std=c$(CSTD) -W -Wall -c -DOSVER=\"$(OSVER)\" $(CSOURCES) $(CCFLAGS)
 endif
 	@mv *.o build/
 	$(ASM) $(NASMSOURCES)


### PR DESCRIPTION
Hello,

this series adds -W -Wall to the C compiler flags, cleans up a few warnings and drops a couple of unused functions.
It then fixes IRQ entry code so that keyboard is working.
I've also made a keyboard controller reset/initialization function, but as it appears to work even without it I'm not including it in that series.

Please review/pull.

-- Jennifer.